### PR TITLE
put data used in tests in global environment with helper_config file

### DIFF
--- a/tests/testthat/helper_config.R
+++ b/tests/testthat/helper_config.R
@@ -1,0 +1,65 @@
+# data from `test-offsets`
+my_dff <- data.frame("x0" = 1:50,
+                     "offs" = 1/(1:50))
+my_dff$y0 <- pmax(0.1, rnorm(50, mean = 10*my_dff$x0 * my_dff$offs, sd = 1))
+
+# data from `test-test-statistic`
+age <- c(72, 81, 90, 72, 70, 72, 75, 75, 67, 70, 86, 71, 75, 70, 79,
+         70, 81, 72, 68, 67, 84, 71, 70, 71, 89, 78, 71, 86, 71, 70, 71,
+         70, 73, 73, 67, 80, 74, 75, 70, 72, 81, 70, 71, 70, 69, 82, 74,
+         74, 72, 68, 73, 84, 79, 76, 86, 71, 67, 75, 72, 75, 78, 70, 74,
+         68, 73, 70, 74, 86, 70, 72, 72, 76, 68, 70, 73, 79, 72, 68, 71,
+         67, 71, 68, 81, 83, 73, 79, 69, 82, 77, 84, 81, 83, 80, 76, 75,
+         79, 75, 72, 75, 79)
+sex <- c("Male", "Female", "Male", "Male", "Female", "Male", "Male",
+         "Male", "Female", "Female", "Female", "Male", "Female", "Female",
+         "Male", "Male", "Male", "Male", "Male", "Female", "Male", "Male",
+         "Male", "Female", "Female", "Male", "Male", "Male", "Male", "Male",
+         "Male", "Female", "Male", "Female", "Male", "Female", "Female",
+         "Female", "Female", "Female", "Female", "Female", "Female", "Male",
+         "Male", "Male", "Female", "Male", "Male", "Male", "Female", "Male",
+         "Male", "Male", "Female", "Male", "Male", "Female", "Female",
+         "Male", "Female", "Female", "Male", "Male", "Male", "Female",
+         "Female", "Male", "Male", "Male", "Female", "Female", "Female",
+         "Male", "Female", "Male", "Female", "Male", "Male", "Female",
+         "Male", "Female", "Male", "Female", "Male", "Male", "Male", "Male",
+         "Female", "Male", "Female", "Male", "Female", "Female", "Male",
+         "Female", "Male", "Female", "Male", "Female")
+weight <- c(173, 139, 145, 190, 153, 154.5, 161.5, 158.2, 168, 127, 139,
+            181.2, 137, 137, 181, 180.5, 151.5, 171, 210, 160, 154, 191,
+            181, 124, 111, 172.5, 167, 167, 152.5, 183.5, 204, 135, 208,
+            168.5, 230, 88, 163, 86, 167, 167, 158, 192, 126, 155, 239, 146,
+            122, 162, 204.2, 168, 136, 156, 170, 193.5, 182, 155, 196, 145.5,
+            135, 159, 118, 141, 241, 158.5, 152, 107, 171, 156, 177, 152,
+            166, 159, 137, 131, 145, 174, 170, 135, 170.5, 142, 186, 217,
+            161, 98, 124, 176, 198, 180.5, 152, 128, 137, 153.5, 130, 97,
+            163, 179, 150, 157, 164.5, 139)
+mri_mini <- data.frame(age, sex, weight)
+
+nsim <- 200
+nn <- 100
+simulate_random_data <- function() {
+  covariate1 <- rnorm(nn)
+  yy <- rpois(nn, lambda = 5 + 0*covariate1)
+  df <- data.frame(covariate1 = covariate1,
+                   yy = yy)
+  return(df)
+}
+
+# data from `test-use-case`
+my_df <- structure(list(yy = c(87928L, 139438L, 163794L, 53806L, 63075L,
+                               27126L, 290005L, 104522L, 170096L, 131047L, 35917L, 36306L, 139066L,
+                               247089L, 106406L, 397543L, 35169L, 153151L, 20801L, 36922L),
+                        xstar = c(17, 12, 13, 21, 18, 28, 15, 15, 15, 16, 21, 19,
+                                  17, 14, 22, 15, 26, 18, 26, 20),
+                        xx = c(94, 78, 86, 101,
+                               92, 111, 108, 88, 97, 97, 93, 86, 103, 99, 120, 115, 110,
+                               110, 99, 90),
+                        predictor = c(-1.71008143821379, -1.87180217690159,
+                                      -1.88939793879197, -1.57059807911784, -1.63141681915288,
+                                      -1.37732569113713, -1.97408102602201, -1.769286613376, -1.86666077740117,
+                                      -1.8021222562636, -1.48807705542983, -1.50990831708707, -1.80151564417342,
+                                      -1.95606252051933, -1.69644928942373, -2.03688192726104,
+                                      -1.44238382777093, -1.81010860789625, -1.33702331211311,
+                                      -1.50407739677627)),
+                   class = c("tbl_df", "tbl", "data.frame"), row.names = c(NA, -20L))

--- a/tests/testthat/test-basic.R
+++ b/tests/testthat/test-basic.R
@@ -42,3 +42,4 @@ test_that("offsets work", {
               "double")
 
 })
+

--- a/tests/testthat/test-test-statistic.R
+++ b/tests/testthat/test-test-statistic.R
@@ -45,50 +45,45 @@ test_that("returns legitimate p-values", {
 })
 
 
-test_that("nominal level test for n=100 under correct model specification", {
-
+test_that("nominal level test for n = 100 under correct model specification", {
+  
+  set.seed(1)
+  nsim <- 200
+  ps <- vector("numeric", length = nsim)
+  
   expect_silent({
-    set.seed(1)
-    nsim = 200
-    ps <- vector("numeric", length=nsim)
-    nn <- 100
-
-    for (i in 1:nsim) {
-      covariate1 <- rnorm(nn)
-      yy <- rpois(nn, lambda = 5 + 0*covariate1)
-      ps[i] <- glm_test(yy ~ covariate1, data = data.frame(covariate1, yy), family=poisson(link="log"))[2, "Robust Score p"]
-
+    for (j in 1:nsim) {
+      ps[j] <- glm_test(yy ~ covariate1,
+                        data = simulate_random_data(),
+                        family = poisson(link = "log"))[2, "Robust Score p"]
     }
   })
 
-
-  expect_true(mean(ps < 0.05) < 0.05 + 2.575*sqrt(0.05*0.95/nsim))
-  expect_true(mean(ps < 0.05) > 0.05 - 2.575*sqrt(0.05*0.95/nsim))
-
+  expect_true(mean(ps < 0.05) < 0.05 + 2.575 * sqrt(0.05 * 0.95/nsim))
+  expect_true(mean(ps < 0.05) > 0.05 - 2.575 * sqrt(0.05 * 0.95/nsim))
 
 })
 
 test_that("p-values are correlated with robust Wald under null", {
 
   set.seed(2)
-  nsim = 200
+  nsim <- 200
   ps_score <- vector("numeric", length=nsim)
-  # ps_rwald <- vector("numeric", length=nsim)
   ps_wald <- vector("numeric", length=nsim)
   nn <- 100
 
   for (i in 1:nsim) {
-    covariate1 <- rnorm(nn)
-    yy <- rpois(nn, lambda = 5 + 0*covariate1)
-    the_glm <- glm_test(yy ~ covariate1, data = data.frame(covariate1, yy), family=poisson(link="log"))
+    the_glm <- glm_test(yy ~ covariate1, 
+                        data = simulate_random_data(), 
+                        family = poisson(link = "log"))
     ps_score[i] <- the_glm[2, "Robust Score p"]
     ps_wald[i] <- the_glm[2, "Robust Wald p"]
   }
 
   lm_res <- coef(summary(lm(ps_score ~ ps_wald)))
-  print(lm_res)
-  expect_equal(lm_res[1,1], 0, tolerance=0.02)
-  expect_equal(lm_res[2,1], 1, tolerance=0.02)
+
+  expect_equal(lm_res[1,1], 0, tolerance = 0.02)
+  expect_equal(lm_res[2,1], 1, tolerance = 0.02)
 
   expect_true(cor(ps_score, ps_wald) > 0.97)
 


### PR DESCRIPTION
Fix problem with failing tests by putting the data used by the tests in the global environment. This mimics what will happen when a user actually runs `glm_test`, because either their data or vectors with their covariates and response variables will be in their environment. 