### PR TITLE
change way of looking for an intercept (or constant column) when removing it 

### DIFF
--- a/R/multinom_test.R
+++ b/R/multinom_test.R
@@ -30,9 +30,10 @@ covariates in formula must be provided.")
     X <- model.matrix(formula, data)
   }
   
-  # if X has intercept column (or a column of repeating values), remove it 
-  if (all(round((X %*% solve(t(X) %*% X) %*% t(X)) %*% rep(1, nrow(X)), 1e-20) == 1)) {
-    X <- X[, -1, drop = FALSE]
+  # if X has intercept column (or a column of constant values across all observations), remove it 
+  constant_cols <- apply(X, 2, function(x) {all(x == mean(x))})
+  if (sum(constant_cols) > 0) {
+    X <- X[, !constant_cols, drop = FALSE]
   }
   
   # check that X and Y have the same number of rows, if not throw error 

--- a/R/multinom_test.R
+++ b/R/multinom_test.R
@@ -31,7 +31,7 @@ covariates in formula must be provided.")
   }
   
   # if X has intercept column (or a column of constant values across all observations), remove it 
-  constant_cols <- apply(X, 2, function(x) {all(x == mean(x))})
+  constant_cols <- apply(X, 2, function(x) {all(x == mean(x, na.rm = TRUE))})
   if (sum(constant_cols) > 0) {
     X <- X[, !constant_cols, drop = FALSE]
   }


### PR DESCRIPTION
Addressing issue with PR #22 in which it would only find and remove an intercept column if it was the first column. This is now more general. Thanks to @gthopkins for noting this! 