### PR TITLE
fix `robust_score_test()` to work for cluster with single observation

### DIFF
--- a/R/robust_score_test.R
+++ b/R/robust_score_test.R
@@ -50,7 +50,7 @@ robust_score_test <- function(glm_object, call_to_model, param = 1,
     for (ii in 1:length(ids)) {
       indices <- which(id == ids[ii])
       n_i <- length(indices)
-      xxi <- xx[indices, ]
+      xxi <- xx[indices, , drop = FALSE]
       model0_fits_i <- model0_fits[indices]
 
       Di <- matrix(NA, nrow = pp, ncol = n_i)
@@ -62,7 +62,11 @@ robust_score_test <- function(glm_object, call_to_model, param = 1,
 
       corr_matrix <- matrix(rep(glm_object$geese$alpha, n_i^2), nrow = n_i)
       diag(corr_matrix) <- 1
-      Vi <- diag(sqrt(model0_fits_i)) %*% corr_matrix %*% diag(sqrt(model0_fits_i))
+      if (n_i > 1) {
+        Vi <- diag(sqrt(model0_fits_i)) %*% corr_matrix %*% diag(sqrt(model0_fits_i))
+      } else {
+        Vi <- sqrt(model0_fits_i) * corr_matrix * sqrt(model0_fits_i)
+      }
 
       Si <- yy[indices] - model0_fits_i
 


### PR DESCRIPTION
Updates to line 53 of `robust_score_test()` to not reduce a matrix to a vector if there is a cluster with a single observation. Update to line 65-69 to adjust `Vi` calculation accordingly. Addresses issue #12 in statdivlab/enviromtx