### PR TITLE
fix permutations in u %*% tu; add tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: raoBust
 Title: Robust score tests for Poisson and Multinomial regression
-Version: 1.0.0.0
+Version: 1.1.0.0
 Authors@R: 
     c(person("Amy", "Willis", , "adwillis@uw.edu", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-2802-4317")), 

--- a/R/multinom_test.R
+++ b/R/multinom_test.R
@@ -5,10 +5,10 @@
 #' @param formula a one-sided formula specifying the form of the mean model to be fit (use with \code{data} argument if \code{X} is not included)
 #' @param data a dataframe with \eqn{n} rows containing variables given in \code{formula} (use with \code{formula} argument if \code{X} is not included)
 #' @param strong If FALSE, this function will compute the robust score statistic to test the weak null that for one specific \eqn{j}, \eqn{\beta_j = 0} for the length \eqn{p} vector \eqn{\beta_j}.
-#' If TRUE, this function instead computes the robust score statistic to test the strong null that \eqn{\beta_1 = \beta_2 = \dots = \beta_{J-1} = 0} for all length \eqn{p} vectors \eqn{\beta_j}, \eqn{j\in\{1,\ldots,J-1\}}. 
+#' If TRUE, this function instead computes the robust score statistic to test the strong null that \eqn{\beta_1 = \beta_2 = \dots = \beta_{J-1} = 0} for all length \eqn{p} vectors \eqn{\beta_j}, \eqn{j\in\{1,\ldots,J-1\}}.
 #' Default is FALSE.
 #' @param j If `strong` is FALSE, this argument must be supplied. This gives the category \eqn{j} in the weak null hypothesis that \eqn{\beta_j = 0}.
-#' @param all_score If TRUE, score tests for each individual covariate and category pair (i.e. null that \eqn{\beta_{jk} = 0} for each category \eqn{j = 1, \dots, J-1} and each covariate \eqn{k = 1, \dots, p} pair) will be 
+#' @param all_score If TRUE, score tests for each individual covariate and category pair (i.e. null that \eqn{\beta_{jk} = 0} for each category \eqn{j = 1, \dots, J-1} and each covariate \eqn{k = 1, \dots, p} pair) will be
 #' run and reported in output coefficient table. Default is FALSE.
 #' @param penalty If TRUE will apply a Firth penalty to estimation under the alternative and under the null. Defaults to FALSE (ask Amy her preference)
 #' @param pseudo_inv Use pseudo inverse for inverted portion of the robust score test to avoid issues with nearly singular matrices.
@@ -21,12 +21,12 @@
 #' @author Shirley Mathur
 #'
 #' @export
-multinom_test <- function(X = NULL, Y, formula = NULL, data = NULL, 
+multinom_test <- function(X = NULL, Y, formula = NULL, data = NULL,
                           strong = FALSE, j = NULL, all_score = FALSE, penalty = FALSE, pseudo_inv = FALSE) {
 
   #record function call
   cl <- match.call()
-  
+
   # if X is null and formula and data are provided, get design matrix
   if (is.null(X)) {
     if (is.null(formula) | is.null(data)) {
@@ -35,31 +35,31 @@ covariates in formula must be provided.")
     }
     X <- model.matrix(formula, data)
   }
-  
-  # if X has intercept column (or a column of constant values across all observations), remove it 
+
+  # if X has intercept column (or a column of constant values across all observations), remove it
   constant_cols <- apply(X, 2, function(x) {all(x == mean(x, na.rm = TRUE))})
   if (sum(constant_cols) > 0) {
     X <- X[, !constant_cols, drop = FALSE]
   }
-  
-  # check that X and Y have the same number of rows, if not throw error 
+
+  # check that X and Y have the same number of rows, if not throw error
   if (nrow(X) != nrow(Y)) {
     stop("Please make sure that X and Y have the same number of observations.")
   }
-  
+
   # check that if X and Y have rownames they are the same, if not throw warning
   if (!is.null(rownames(X)) & !is.null(rownames(Y))) {
     if (!(all.equal(rownames(X), rownames(Y)) == TRUE)) {
-      warn("X and Y both have rownames, and they do not match. Please check that the rows of X and Y correspond to the 
+      warn("X and Y both have rownames, and they do not match. Please check that the rows of X and Y correspond to the
          same observations.")
     }
   }
-  
+
   #get n, p, J values (used throughout rest of the function to compute relevant quantities)
   n <- nrow(Y)
   p <- ncol(X)
   J <- ncol(Y)
-  
+
   #compute other necessary quantities needed for computations
   N <- matrix(apply(Y, MARGIN = 1, FUN = sum), nrow = n) #totals by sample
   Xaug <- cbind(matrix(rep(1, n), ncol = 1), X) #augmented covariate matrix
@@ -93,7 +93,7 @@ covariates in formula must be provided.")
 
     #information matrix evaluated at mle under null constraint
     I1 <- multinom_info_mat(X, Y, ps_full)
-    
+
     #D matrix (sum of S_iS_i^T for all i = 1, \dots, n)
     D1 <- matrix(data = rep(0, length(S1)^2), ncol = length(S1))
     for (k in 1:(J-1)) {
@@ -107,11 +107,13 @@ covariates in formula must be provided.")
     the_mle <- beta_null1mle
     the_df <- p
 
+
     #compute statistic!
     if (!pseudo_inv) {
-      T_GS<- tryCatch({as.numeric(t(S1) %*% solve(I1) %*% t(H1) %*%
-                                    (solve(H1 %*% solve(I1) %*% D1 %*% solve(I1) %*% t(H1))) %*%
-                                    H1 %*% solve(I1) %*% S1)},
+      ## Recall solve(x1, x2) is the same as solve(x1) %*% x2
+      T_GS<- tryCatch({as.numeric(t(S1) %*% solve(I1, t(H1)) %*%
+                                    solve(H1 %*% solve(I1, D1) %*% solve(I1, t(H1)),
+                                          H1 %*% solve(I1, S1)))},
                       error = function(cond) {
                         print(cond)
                         return(NA)
@@ -125,7 +127,7 @@ covariates in formula must be provided.")
                         return(NA)
                       })
     }
-    
+
 
   } else {
     #initialize value for beta_k0 for all k = 1, \dots, J-1
@@ -176,9 +178,9 @@ covariates in formula must be provided.")
 
     #compute statistic!
     if (!pseudo_inv) {
-      T_GS <- tryCatch({as.numeric(t(S2) %*% solve(I2) %*% t(H2) %*%
-                                     (solve(H2 %*% solve(I2) %*% D2 %*% solve(I2) %*% t(H2))) %*%
-                                     H2 %*% solve(I2) %*% S2)},
+      T_GS <- tryCatch({as.numeric(t(S2) %*% solve(I2, t(H2)) %*%
+                                     solve(H2 %*% solve(I2, D2) %*% solve(I2, t(H2)),
+                                           H2 %*% solve(I2, S2)))},
                        error = function(cond) {
                          warning("Test statistic cannot be calculated due to the error printed above.")
                          print(cond)
@@ -194,12 +196,12 @@ covariates in formula must be provided.")
                          return(NA)
                        })
     }
-    
+
 
 
   }
-  
-  
+
+
   #run score test for each coefficient (all covariate and category pairs) if desired
   score_test_pvals <- matrix(NA, nrow = p+1, ncol = J-1)
   if (all_score) {
@@ -208,7 +210,7 @@ covariates in formula must be provided.")
         #jacobian of function of parameter h(\beta) = 0
         H3 <- matrix(data = rep(0, (p+1)*(J-1)), nrow = 1)
         H3[1,(j-1)*(p+1)+m] <- 1
-        
+
         #compute mle under null constraint
         beta_init <- matrix(1, nrow = p + 1, ncol = J-1)
         beta_init[m,j] <- 0
@@ -217,17 +219,17 @@ covariates in formula must be provided.")
         } else {
           beta_null3mle <- multinom_penalized_estimation(beta_init, X, Y, j_ind = j, k_ind = m, pseudo_inv = pseudo_inv)
         }
-        
+
         #terms necessary for computation of S, I, D matrices
         ps_full <- multinom_get_probs(X, Y, beta_null3mle)
-        
-        
+
+
         #score of \beta evaluated at mle under null constraint
         S3 <- multinom_score_vector(X, Y, ps_full)
-        
+
         #information matrix evaluated at mle under null constraint
         I3 <- multinom_info_mat(X, Y, ps_full)
-        
+
         #D matrix (sum of S_iS_i^T for all i = 1, \dots, n)
         D3 <- matrix(data = rep(0, length(S3)^2), ncol = length(S3))
         for (k in 1:(J-1)) {
@@ -237,14 +239,14 @@ covariates in formula must be provided.")
             D3[((k-1)*(p+1) + 1):(k*(p+1)) ,((l-1)*(p+1) + 1):(l*(p+1))] <- t(S3_k)%*%S3_l
           }
         }
-        
+
         temp_mle <- beta_null3mle
-        
+
         #compute statistic!
         if (!pseudo_inv) {
-          temp_GS <- tryCatch({as.numeric(t(S3) %*% solve(I3) %*% t(H3) %*%
-                                            (solve(H3 %*% solve(I3) %*% D3 %*% solve(I3) %*% t(H3))) %*%
-                                            H3 %*% solve(I3) %*% S3)},
+          temp_GS <- tryCatch({as.numeric(t(S3) %*% solve(I3, t(H3)) %*%
+                                            solve(H3 %*% solve(I3, D3) %*% solve(I3, t(H3)),
+                                                  H3 %*% solve(I3, S3)))},
                               error = function(cond) {
                                 warning("Test statistic cannot be calculated due to the error printed above.")
                                 print(cond)
@@ -260,15 +262,15 @@ covariates in formula must be provided.")
                                 return(NA)
                               })
         }
-        
+
         #get pval for test and record
         score_test_pvals[m,j] <- pchisq(temp_GS, df = 1, lower.tail = FALSE)
       }
     }
-    
+
   }
 
-  
+
   #compute mle under alternative
   beta_alt <- matrix(-0.02, nrow = p + 1, ncol = J-1)
   if (!penalty) {
@@ -286,17 +288,17 @@ covariates in formula must be provided.")
                           return(NA)
                         })
   }
-  
+
   #compute robust Wald SE's
   #terms necessary for computation of S, I, D matrices
   ps_alt <-   multinom_get_probs(X, Y, mle_alt)
-  
+
   #score of \beta evaluated at mle under alternative
   S_alt <- multinom_score_vector(X, Y, ps_alt)
-  
+
   #information matrix evaluated at mle under alternative
   I_alt <- multinom_info_mat(X, Y, ps_alt)
-  
+
   #D matrix (sum of S_iS_i^T for all i = 1, \dots, n) for mle under alternative
   D_alt <- matrix(data = rep(0, length(S_alt)^2), ncol = length(S_alt))
   for (k in 1:(J-1)) {
@@ -306,16 +308,16 @@ covariates in formula must be provided.")
       D_alt[((k-1)*(p+1) + 1):(k*(p+1)) ,((l-1)*(p+1) + 1):(l*(p+1))] <- t(S_alt_k)%*%S_alt_l
     }
   }
-  
-  robust_wald_cov <- solve(I_alt) %*% D_alt %*% solve(I_alt)
+
+  robust_wald_cov <- solve(I_alt, D_alt) %*% solve(I_alt)
   robust_wald_se <- matrix(sqrt(diag(robust_wald_cov)), nrow = p+1, ncol = J-1, byrow = FALSE)
-  
+
   #make table of coefficients
   cat_labs <- 1:ncol(Y)
   if(!is.null(colnames(Y))) {
     cat_labs <- colnames(Y)
   }
-  
+
   coef_tab <- data.frame("Category" = rep(cat_labs[1:J-1], each = p+1),
                          "Covariate" = rep(1:(p+1), J-1),
                          "Estimate" = rep(NA, (p+1)*(J-1)),
@@ -325,19 +327,19 @@ covariates in formula must be provided.")
                          "Robust Wald p" = rep(NA, (p+1)*(J-1)),
                          "Robust Score p" = rep(NA, (p+1)*(J-1)),
                          check.names = FALSE)
-  
+
   #set covariate terms appropriately if formula was used in call
   if (!is.null(formula)) {
-    
+
     #get names of variables used for model fit, and then use these to populate covariate column of output table
     coef_names <- c(labels(terms(as.formula(formula), data = data)))
     coef_tab$Covariate <- rep(c("(intercept)",coef_names), J-1)
-    
+
   } else {
-    if (is.null(colnames(X))) {coef_names <- 1:ncol(X)} else {coef_names <- colnames(X)} 
+    if (is.null(colnames(X))) {coef_names <- 1:ncol(X)} else {coef_names <- colnames(X)}
     coef_tab$Covariate <- rep(c("(intercept)", coef_names), J-1)
   }
-  
+
   #populate estimate, se, Wald p, and lower and upper columns of output table with appropriate quantities
   coef_tab$Estimate <- c(mle_alt)
   coef_tab$'Robust Std Error' <- c(robust_wald_se)
@@ -345,7 +347,7 @@ covariates in formula must be provided.")
   coef_tab$'Lower 95% CI' <- coef_tab$Estimate + qnorm(0.025)*coef_tab$'Robust Std Error'
   coef_tab$'Upper 95% CI' <- coef_tab$Estimate + qnorm(0.975)*coef_tab$'Robust Std Error'
   coef_tab$'Robust Score p' <- c(score_test_pvals)
-  
+
   #sort table by magnitude of effect size
   coef_tab <- coef_tab[order(abs(coef_tab$Estimate), decreasing = TRUE), ]
 
@@ -359,7 +361,7 @@ covariates in formula must be provided.")
                  "wald_se" = robust_wald_se,
                  "coef_tab" = coef_tab,
                  "penalty" = penalty)
-  
+
   return(structure(result, class = "raoFit"))
 
 }

--- a/R/robust_score_test.R
+++ b/R/robust_score_test.R
@@ -73,8 +73,9 @@ robust_score_test <- function(glm_object, call_to_model, param = 1,
 
       Si <- yy[indices] - model0_fits_i
 
-      Umatrices[[ii]] <- Di %*% solve(Vi) %*% matrix(Si, ncol = 1)
-      Amatrices[[ii]] <- Di %*% solve(Vi) %*% t(Di)
+      ## Recall solve(x1, x2) is the same as solve(x1) %*% x2
+      Umatrices[[ii]] <- Di %*% solve(Vi, matrix(Si, ncol = 1))
+      Amatrices[[ii]] <- Di %*% solve(Vi, t(Di))
 
     }
 
@@ -86,7 +87,7 @@ robust_score_test <- function(glm_object, call_to_model, param = 1,
     u_tilde_sum <- Pi %*% Reduce("+", Umatrices) # p x 1
     # u_tilde_sum <- matrix(c(u_tilde_sum[-param,1], u_tilde_sum[param,1]), ncol = 1)
 
-    ### Compute B and reorder
+    ### Compute B and reorde
     # Bhat <- (Reduce("+", lapply(FUN = function(x) { x %*% t(x) }, Umatrices)))
     Bhat <- Reduce("+", lapply(Umatrices, function(u) {
       up <- Pi %*% u
@@ -95,7 +96,7 @@ robust_score_test <- function(glm_object, call_to_model, param = 1,
 
     ### Compute A
     aa0 <- Reduce("+", Amatrices) ### p x p
-    ## Reorder a
+    ## Reorder A
     aa0_11 <- aa0[setdiff(seq_len(pp), param), setdiff(seq_len(pp), param)]
     aa0_22 <- aa0[param, param]
     aa0_21 <- aa0[param, setdiff(seq_len(pp), param)]
@@ -103,8 +104,8 @@ robust_score_test <- function(glm_object, call_to_model, param = 1,
 
     ## Reorder B
     test_stat <- c(t(c_tilde %*% u_tilde_sum) %*% ## (1 x p) x (p x 1)
-                     solve(c_tilde %*% Bhat %*% t(c_tilde)) %*% # (1 x p) x ((p x n) x (n x p)) x (p x 1)
-                     (c_tilde %*% u_tilde_sum))
+                     solve(c_tilde %*% Bhat %*% t(c_tilde), # (1 x p) x ((p x n) x (n x p)) x (p x 1)
+                           (c_tilde %*% u_tilde_sum)))
 
   } else if (is.na(id)) {
 
@@ -122,8 +123,8 @@ robust_score_test <- function(glm_object, call_to_model, param = 1,
     c_tilde <- cbind(-aa0_21 %*% solve(aa0_11), diag(rep(1, pp0))) # 1 x p
 
     test_stat <- c(t(c_tilde %*% matrix(rowSums(u_tilde), ncol = 1)) %*% ## (1 x p) x (p x 1)
-                     solve(c_tilde %*% (u_tilde %*% t(u_tilde)) %*% t(c_tilde)) %*% # (1 x p) x ((p x n) x (n x p)) x (p x 1)
-                     (c_tilde %*% matrix(rowSums(u_tilde), ncol = 1)))
+                     solve(c_tilde %*% (u_tilde %*% t(u_tilde)) %*% t(c_tilde), # (1 x p) x ((p x n) x (n x p)) x (p x 1)
+                           (c_tilde %*% matrix(rowSums(u_tilde), ncol = 1))))
   } else {
 
     stop("unsure what correlation structure is")

--- a/tests/testthat/test-multinom_pseudo_inv.R
+++ b/tests/testthat/test-multinom_pseudo_inv.R
@@ -1,11 +1,11 @@
-nsim <- 100
+nsim <- 5
 
 test_that("using the inverse and pseudo inverse give the same results when an inverse exists", {
-  
+
   nn <- 10
   stat <- rep(NA, 50)
   stat_alt <- rep(NA, 50)
-  
+
   for (sim in 1:nsim) {
     set.seed(sim)
     df <- simulate_data_mult(nn = nn, strong=TRUE)
@@ -16,15 +16,16 @@ test_that("using the inverse and pseudo inverse give the same results when an in
   }
 
   expect_true(all.equal(stat, stat_alt, tol = 1e-03))
-  
+
 })
 
+nsim <- 100
 test_that("the test stat with the pseudo inverse controls t1e when the inverse is computationally singular for strong hypothesis", {
-  
+
   nn <- 10
   p <- rep(NA, 50)
   p_alt <- rep(NA, 50)
-  
+
   for (sim in 1:nsim) {
     set.seed(sim)
     df <- simulate_data_mult(nn = nn, strong=TRUE, ms = 10)
@@ -35,22 +36,23 @@ test_that("the test stat with the pseudo inverse controls t1e when the inverse i
     p[sim] <- result$p
     p_alt[sim] <- result_alt$p
   }
-  
+
+  expect_true(sum(!is.na(p)) > 5)
   expect_true(all.equal(p[!is.na(p)], p_alt[!is.na(p)], tol = 0.005))
   expect_true(mean(p_alt < 0.05) < 0.05 + 1.96*sqrt(0.05 * 0.95/nsim))
   expect_true(mean(p_alt < 0.10) < 0.1 + 1.96*sqrt(0.1 * 0.9/nsim))
-  
+
 })
 
 test_that("the test stat with the pseudo inverse controls t1e when the inverse is computationally singular for weak hypothesis", {
-  
+
   # I'm having trouble coming up with times in which there are computationally singular errors
   # for the weak null
-  
+
   nn <- 6
   p <- rep(NA, 50)
   p_alt <- rep(NA, 50)
-  
+
   for (sim in 1:nsim) {
     set.seed(sim)
     df <- simulate_data_mult(nn = nn, strong=FALSE, jj_null = 2, ms = 100)
@@ -62,19 +64,19 @@ test_that("the test stat with the pseudo inverse controls t1e when the inverse i
     p[sim] <- result$p
     p_alt[sim] <- result_alt$p
   }
-  
+
   expect_true(all.equal(p[!is.na(p)], p_alt[!is.na(p)], tol = 0.0001))
   expect_true(mean(p_alt < 0.05) < 0.05 + 1.96*sqrt(0.05 * 0.95/nsim))
   expect_true(mean(p_alt < 0.10) < 0.1 + 1.96*sqrt(0.1 * 0.9/nsim))
-  
+
 })
 
 test_that("power increases with signal for the test stat with the pseudo inverse when the inverse is computationally singular for strong hypothesis", {
-  
+
   nn <- 20
   p <- rep(NA, 50)
   p_alt <- rep(NA, 50)
-  
+
   for (sim in 1:nsim) {
     set.seed(sim)
     df <- simulate_data_mult(nn = nn, null = FALSE, ms = 10)
@@ -85,13 +87,13 @@ test_that("power increases with signal for the test stat with the pseudo inverse
     p[sim] <- result$p
     p_alt[sim] <- result_alt$p
   }
-  
+
   expect_true(all.equal(p[!is.na(p)], p_alt[!is.na(p)], tol = 0.05))
-  
+
   nn <- 20
   p2 <- rep(NA, 50)
   p_alt2 <- rep(NA, 50)
-  
+
   for (sim in 1:nsim) {
     set.seed(sim)
     df <- simulate_data_mult(nn = nn, null = FALSE, ms = 10, alt_magnitude = 3)
@@ -102,19 +104,19 @@ test_that("power increases with signal for the test stat with the pseudo inverse
     p2[sim] <- result$p
     p_alt2[sim] <- result_alt$p
   }
-  
-  # there are some bigger differences for this set 
+
+  # there are some bigger differences for this set
   #expect_true(all.equal(p2[!is.na(p2)], p_alt2[!is.na(p2)], tol = 0.3))
   expect_true(mean(p_alt2 < 0.05) > mean(p_alt < 0.05))
-  
+
 })
 
 test_that("power increases with signal for the test stat with the pseudo inverse when the inverse is computationally singular for strong hypothesis", {
-  
+
   nn <- 20
   p <- rep(NA, 50)
   p_alt <- rep(NA, 50)
-  
+
   for (sim in 1:nsim) {
     set.seed(sim)
     df <- simulate_data_mult(nn = nn, null = FALSE, ms = 100)
@@ -126,13 +128,13 @@ test_that("power increases with signal for the test stat with the pseudo inverse
     p[sim] <- result$p
     p_alt[sim] <- result_alt$p
   }
-  
+
   expect_true(all.equal(p[!is.na(p)], p_alt[!is.na(p)], tol = 0.005))
-  
+
   nn <- 20
   p2 <- rep(NA, 50)
   p_alt2 <- rep(NA, 50)
-  
+
   for (sim in 1:nsim) {
     set.seed(sim)
     df <- simulate_data_mult(nn = nn, null = FALSE, ms = 100, alt_magnitude = 3)
@@ -144,9 +146,9 @@ test_that("power increases with signal for the test stat with the pseudo inverse
     p2[sim] <- result$p
     p_alt2[sim] <- result_alt$p
   }
-  
-  # there are some bigger differences for this set 
+
+  # there are some bigger differences for this set
   expect_true(all.equal(p2[!is.na(p2)], p_alt2[!is.na(p2)], tol = 0.001))
   expect_true(mean(p_alt2 < 0.05) > mean(p_alt < 0.05))
-  
+
 })

--- a/tests/testthat/test-permute-row-order.R
+++ b/tests/testthat/test-permute-row-order.R
@@ -1,0 +1,123 @@
+set.seed(3)
+
+### specifics not important, just for generating data
+n_clust = 10; m = 3; sigma_b = 0.2; rho = 0.2
+nn <- n_clust * m
+F   <- rnorm(nn)
+E   <- matrix(rnorm(nn * 4), nn, 4)
+X   <- sqrt(rho) * F + sqrt(1 - rho) * E
+X   <- scale(X, center = TRUE, scale = TRUE)
+covariate1 <- X[, 1]; covariate2 <- X[, 2]
+covariate3 <- X[, 3]; covariate4 <- X[, 4]
+id  <- rep(1:n_clust, each = m)
+b <- rnorm(n_clust, mean = 0, sd = sigma_b)
+
+eta <- 1 + -1*covariate1 + 0*covariate2 + -1*covariate3 + 1*covariate4 + b[id]
+mu  <- exp(eta)
+
+yy  <- rpois(nn, lambda = mu)
+
+df_re <- data.frame(
+  id = id,
+  covariate1, covariate2, covariate3, covariate4,
+  yy = yy
+)
+
+
+expect_silent(glm_coef_default <- glm_test(
+  formula = yy ~ covariate1 + covariate2 + covariate3 + covariate4,
+  family  = poisson(link = "log"),
+  data    = df_re
+)$coef)
+expect_type(glm_coef_default, "double")
+
+
+expect_silent(gee_coef_default <- gee_test(
+  formula = yy ~ covariate1 + covariate2 + covariate3 + covariate4,
+  family  = poisson(link = "log"),
+  id      = id,
+  data    = df_re
+)$coef)
+
+expect_type(gee_coef_default, "list")
+
+test_that("invariant to row order", {
+
+  ### glm_test fine
+  expect_equal(
+    glm_coef_default,
+    glm_test(
+      formula = yy ~ covariate1 + covariate2 + covariate3 + covariate4,
+      family  = poisson(link = "log"),
+      data    = df_re[sample(1:nrow(df_re), replace=FALSE), ]
+    )$coef
+  )
+
+  expect_equal(
+    gee_coef_default,
+    gee_test(
+      formula = yy ~ covariate1 + covariate2 + covariate3 + covariate4,
+      family  = poisson(link = "log"),
+      id      = id,
+      data    = df_re[nrow(df_re):1, ]
+    )$coef
+  )
+
+
+  expect_equal(
+    gee_coef_default,
+    gee_test(
+      formula = yy ~ covariate1 + covariate2 + covariate3 + covariate4,
+      family  = poisson(link = "log"),
+      id      = id,
+      data    = df_re[c(4:nrow(df_re), 1:3), ]
+    )$coef
+  )
+
+  expect_equal(
+    gee_coef_default,
+    gee_test(
+      formula = yy ~ covariate1 + covariate2 + covariate3 + covariate4,
+      family  = poisson(link = "log"),
+      id      = id,
+      data    = df_re[c(4:nrow(df_re), 3:1), ]
+    )$coef
+  )
+
+  my_reorder <- sample(1:nrow(df_re), replace=FALSE)
+  expect_equal(
+    gee_coef_default,
+    gee_test(
+      formula = yy ~ covariate1 + covariate2 + covariate3 + covariate4,
+      family  = poisson(link = "log"),
+      id      = id,
+      data    = df_re[my_reorder, ]
+    )$coef
+  )
+
+})
+
+
+test_that("invariant to column order", {
+
+  expect_equal(
+    glm_coef_default,
+    glm_test(
+      formula = yy ~ covariate2 + covariate1 + covariate3 + covariate4,
+      family  = poisson(link = "log"),
+      data    = df_re
+    )$coef[c(1,3,2,4,5), ]
+  )
+
+  ### robust score test differs
+  ###   FAILING
+  expect_equal(
+    gee_coef_default,
+    gee_test(
+      formula = yy ~ covariate2 + covariate1 + covariate3 + covariate4,
+      family  = poisson(link = "log"),
+      id      = id,
+      data    = df_re
+    )$coef[c(1,3,2,4,5,6), ]
+  )
+})

--- a/tests/testthat/test_multinom_lincom.R
+++ b/tests/testthat/test_multinom_lincom.R
@@ -3,80 +3,80 @@ test_that("lincom function works as expected when linear combination is checking
   beta0s <- rnorm(n = 4)
   beta1s <- rnorm(n = 4)
   beta_true <- rbind(beta0s, beta1s)
-  beta_true[,2] <- 0 
-  beta_true[2,1] <- 0 
-  
+  beta_true[,2] <- 0
+  beta_true[2,1] <- 0
+
   #generate sample data
   sample_data <- simulate_data_mult(30, Beta = beta_true)
-  
+
   #run weak multinom test
   sample_multinom_test <- multinom_test(X = sample_data$X,
                                         Y = sample_data$Y,
                                         j = 2)
-  
+
   #test hypothesis that the coefficient for k=1, j = 1 is 0
   #first, set up A matrix
-  my_A <- set_up_lin_com(J = 5, p = 1, n_hypotheses = 1) 
+  my_A <- set_up_lin_com(J = 5, p = 1, n_hypotheses = 1)
   my_A[1,"k_1_j_1"] <- 1
-  
+
   #then, set c
   my_c <- 0
-  
+
   #run linear combination test
   sample_lincom_test <- lincom(sample_multinom_test,
                                A = my_A,
                                c = my_c)
-  
+
   #compare value from lincom test and the wald test from test object
   sample_test_coef_tab <- sample_multinom_test$coef_tab
   sample_test_relevant_res <- sample_test_coef_tab[sample_test_coef_tab$"Category" == 1 & sample_test_coef_tab$"Covariate" == 1, ]
-  
+
   expect_true(all.equal(unlist(unname(sample_test_relevant_res[1,3:7])), unlist(unname(sample_lincom_test[1,1:5]))))
 })
 
 test_that("type 1 error is controlled for lincom test", {
-  
+
   skip("Skipping due to time, can check manually")
-  
+
   #set up simulation parameters
   set.seed(13)
   nsim <- 1000
   n <- 200
   J <- 10
   null_j <- 2
-  
+
   #set true value of beta for DGP
   beta0s <- rnorm(n = 9)
   beta1s <- rnorm(n = 9)
   beta_true <- rbind(beta0s, beta1s)
   beta_true[,1] <- beta_true[,2]
-  
+
   #set up matrix for testing hypothesis that beta_{k=1,j=1} - beta_{k=1,j=2} = 0
   A <- set_up_lin_com(J, 1, 1)
   A[1, c("k_1_j_1", "k_1_j_2")] <- c(1,-1)
-  
+
   #set up vector storing p-values
   lincom_sim_pvals <- rep(NA, nsim)
-  
+
   #do simulation
   for (i in 1:nsim) {
-    
+
     #generate data
     sim_weak_data_true <- simulate_data_mult(n, Beta = beta_true, overdispersion = 1)
-    
+
     #run test for weak null hypothesis
     weak_multinom_res <- multinom_test(X = sim_weak_data_true$X, Y = sim_weak_data_true$Y, j = null_j)
-    
+
     #run lincom test
     lincom_res <- lincom(weak_multinom_res, A, 0)
-    
+
     #store pval result
     lincom_sim_pvals[i] <- lincom_res$pval
   }
-  
+
   expect_true(mean(lincom_sim_pvals < 0.05) < 0.05 + 2.575 * sqrt(0.05 * 0.95/nsim))
-  expect_true(mean(lincom_sim_pvals > 0.05) > 0.05 - 2.575 * sqrt(0.05 * 0.95/nsim))
-  
+  expect_true(mean(lincom_sim_pvals > 0.05) > 0.95 - 2.575 * sqrt(0.05 * 0.95/nsim))
+
 })
 
 


### PR DESCRIPTION
# The problem: changing the order of covariate changed the results

These should have been the same but weren't. This only impacted exchangeable correlation structures. Independence was fine. 

```
gee_test(
  formula = yy ~ covariate1 + covariate2 + covariate3 + covariate4,
  family  = poisson(link = "log"),
  id      = id,
  data    = df_re
)$coef
gee_test(
      formula = yy ~ covariate2 + covariate1 + covariate3 + covariate4,
      family  = poisson(link = "log"),
      id      = id,
      data    = df_re
    )$coef[c(1,3,2,4,5,6), ]
```

The issue was that we were not permuting u %*% tu to align with the parametrization of (null params, nonnull params).... or maybe the reverse order, it's not important. 

Also add tests to check this in future. 

@svteichman I had previously thought that a similar issue came up with reordering the rows -- but this was actually not an issue. (I've added a test to confirm.) I also learnt that `df_re[my_reorder, ]` leads to different results than `df_re[sample(1:nrow(df_re), replace=FALSE), ]`... presumably because the other arguments' order matters here too (I would have thought it would have directly accessed them from data, though). Good to know!

This is not ready for review yet. I will request when it is. I'm also cleaning up a few minor things and running some more tests. 