### PR TITLE
Missing data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: raoBust
 Title: Robust score tests for generalized linear models
-Version: 1.1.1.0
+Version: 1.1.2.0
 Authors@R: 
     c(person("Amy", "Willis", , "adwillis@uw.edu", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-2802-4317")), 

--- a/R/gee_test.R
+++ b/R/gee_test.R
@@ -60,7 +60,7 @@ gee_test <- function(use_geeasy = TRUE, use_jack_se = FALSE, cluster_corr_coef =
   id_clean  <- eval(cl$id, envir = rlang::caller_env())[the_reorder]
   
   # drop rows with any NA
-  keep_rows <- complete.cases(dat_clean)
+  keep_rows <- stats::complete.cases(dat_clean)
   dat_clean <- dat_clean[keep_rows, ]
   id_clean  <- id_clean[keep_rows]
   

--- a/R/glm_test.R
+++ b/R/glm_test.R
@@ -1,6 +1,6 @@
 #' Generalized Linear Models with robust and non-robust Wald and Rao (score) tests
 #'
-#' @param ... Arguments that you would pass to a regular `glm` call. Note that for now we only have functionality for Poisson tests with log link
+#' @param ... Arguments that you would pass to a regular `glm` call. Any observations with `NA` values in the data (response or covariates) will be dropped.
 #'
 #' @importFrom sandwich sandwich
 #' @importFrom stats coef glm pnorm qnorm

--- a/R/multinom_fisher_scoring.R
+++ b/R/multinom_fisher_scoring.R
@@ -89,7 +89,7 @@ multinom_fisher_scoring <- function(beta, X, Y, null = TRUE, strong = FALSE, nul
     if (!pseudo_inv) {
       step_dir <- tryCatch({solve(info_mat) %*% score},
                            error = function(cond) {
-                             print(cont)
+                             print(cond)
                              return(NA)
                             })
     } else {

--- a/R/multinom_test.R
+++ b/R/multinom_test.R
@@ -332,7 +332,7 @@ covariates in formula must be provided.")
   if (!is.null(formula)) {
 
     #get names of variables used for model fit, and then use these to populate covariate column of output table
-    coef_names <- c(labels(terms(as.formula(formula), data = data)))
+    coef_names <- c(labels(stats::terms(stats::as.formula(formula), data = data)))
     coef_tab$Covariate <- rep(c("(intercept)",coef_names), J-1)
 
   } else {

--- a/man/gee_test.Rd
+++ b/man/gee_test.Rd
@@ -22,7 +22,7 @@ instead be performed with a GLM.}
 
 \item{skip_gee}{When TRUE doesn't try to optimize with a GEE (just uses a GLM). This should only be used internally for testing.}
 
-\item{...}{Arguments that you would pass to a regular \code{geepack::geeglm} call. Note that for now we only have functionality for Poisson tests with log link}
+\item{...}{Arguments that you would pass to a regular \code{geepack::geeglm} call. Any observations with \code{NA} values in the data (response or covariates) will be dropped.}
 }
 \description{
 Generalized Estimating Equations under technical replication with robust and non-robust Wald and Rao (score) tests

--- a/man/glm_test.Rd
+++ b/man/glm_test.Rd
@@ -7,7 +7,7 @@
 glm_test(...)
 }
 \arguments{
-\item{...}{Arguments that you would pass to a regular \code{glm} call. Note that for now we only have functionality for Poisson tests with log link}
+\item{...}{Arguments that you would pass to a regular \code{glm} call. Any observations with \code{NA} values in the data (response or covariates) will be dropped.}
 }
 \description{
 Generalized Linear Models with robust and non-robust Wald and Rao (score) tests

--- a/tests/testthat/test-missing_data.R
+++ b/tests/testthat/test-missing_data.R
@@ -1,0 +1,133 @@
+test_that("see what happens with missing data", {
+  
+  set.seed(1)
+  n_clust = 10
+  m = 3
+  sigma_b = 0.1
+  rho = 0.2
+  nn <- n_clust * m
+  
+  #### generate covariates to be correlated. rho = 0 means uncorrelated.
+  F   <- rnorm(nn)
+  E   <- matrix(rnorm(nn * 4), nn, 4)
+  X   <- sqrt(rho) * F + sqrt(1 - rho) * E
+  X   <- scale(X, center = TRUE, scale = TRUE)
+  
+  covariate1 <- X[, 1]; covariate2 <- X[, 2]
+  covariate3 <- X[, 3]; covariate4 <- X[, 4]
+  
+  #### generate observations to be cluster correlated via random effect
+  id  <- rep(1:n_clust, each = m)
+  b <- rnorm(n_clust, mean = 0, sd = sigma_b)
+  
+  #### can toggle effect sizes here
+  eta <- 1 + -3*covariate1 - 0*covariate2 + -1*covariate3 + 1*covariate4 + b[id]
+  mu  <- exp(eta)
+  
+  yy  <- rpois(nn, lambda = mu)
+  
+  yy[5] <- NA # TODO stress test
+  
+  df_re <- data.frame(
+    id = id,
+    covariate1, covariate2, covariate3, covariate4,
+    yy = yy
+  )
+  
+  # see what happens for glm when missing y value
+  res_all <- glm_test(
+    formula = yy ~ covariate1 + covariate2 + covariate3 + covariate4,
+    family  = poisson(link = "log"),
+    data    = df_re
+  )
+  res_no_5 <- glm_test(
+    formula = yy ~ covariate1 + covariate2 + covariate3 + covariate4,
+    family  = poisson(link = "log"),
+    data    = df_re[-5,]
+  )
+  expect_true(all.equal(res_all$coef_tab, res_no_5$coef_tab))
+  
+  # how about gee? 
+  gee_res_all <- gee_test(
+    formula = yy ~ covariate1 + covariate2 + covariate3 + covariate4,
+    family  = poisson(link = "log"),
+    id      = id,
+    data    = df_re
+  )
+  gee_res_no5 <- gee_test(
+    formula = yy ~ covariate1 + covariate2 + covariate3 + covariate4,
+    family  = poisson(link = "log"),
+    id      = id,
+    data    = df_re[-5, ]
+  )
+  gee_res_geelm <- gee_test(
+    formula = yy ~ covariate1 + covariate2 + covariate3 + covariate4,
+    family  = poisson(link = "log"),
+    id      = id,
+    data    = df_re,
+    use_geeasy = FALSE
+  )
+  gee_res_geelm_no5 <- gee_test(
+    formula = yy ~ covariate1 + covariate2 + covariate3 + covariate4,
+    family  = poisson(link = "log"),
+    id      = id,
+    data    = df_re[-5, ],
+    use_geeasy = FALSE
+  )
+  all.equal(gee_res_no5$coef_tab, gee_res_all$coef_tab)
+  all.equal(gee_res_geelm$coef_tab, gee_res_geelm_no5$coef_tab)
+  
+  # what if it is covariate that is missing? 
+  yy  <- rpois(nn, lambda = mu)
+  
+  covariate2[4] <- NA # TODO stress test
+  
+  df_re <- data.frame(
+    id = id,
+    covariate1, covariate2, covariate3, covariate4,
+    yy = yy
+  )
+  
+  # see what happens for glm when missing y value
+  res_all <- glm_test(
+    formula = yy ~ covariate1 + covariate2 + covariate3 + covariate4,
+    family  = poisson(link = "log"),
+    data    = df_re
+  )
+  res_no_4 <- glm_test(
+    formula = yy ~ covariate1 + covariate2 + covariate3 + covariate4,
+    family  = poisson(link = "log"),
+    data    = df_re[-4,]
+  )
+  expect_true(all.equal(res_all$coef_tab, res_no_4$coef_tab))
+  
+  # how about gee? 
+  gee_res_all <- gee_test(
+    formula = yy ~ covariate1 + covariate2 + covariate3 + covariate4,
+    family  = poisson(link = "log"),
+    id      = id,
+    data    = df_re
+  )
+  gee_res_no4 <- gee_test(
+    formula = yy ~ covariate1 + covariate2 + covariate3 + covariate4,
+    family  = poisson(link = "log"),
+    id      = id,
+    data    = df_re[-4, ]
+  )
+  all.equal(gee_res_no4$coef_tab, gee_res_all$coef_tab)
+  gee_res_geelm <- gee_test(
+    formula = yy ~ covariate1 + covariate2 + covariate3 + covariate4,
+    family  = poisson(link = "log"),
+    id      = id,
+    data    = df_re,
+    use_geeasy = FALSE
+  )
+  gee_res_no4_geelm <- gee_test(
+    formula = yy ~ covariate1 + covariate2 + covariate3 + covariate4,
+    family  = poisson(link = "log"),
+    id      = id,
+    data    = df_re[-4, ],
+    use_geeasy = FALSE
+  )
+  all.equal(gee_res_no4_geelm$coef_tab, gee_res_geelm$coef_tab)
+})


### PR DESCRIPTION
- add tests for missing data from `glm_test()` and `gee_test()`
- explicitly enforcing removal of incomplete cases for `gee_test()` to avoid warning (which wasn't affecting results)
- document for `gee_test()` and `glm_test()` that incomplete cases will be removed 

This addresses issue #38 