### PR TITLE
invert Vi with a penalty for cases with computationally singular Vi matrix

### DIFF
--- a/man/gee_test.Rd
+++ b/man/gee_test.Rd
@@ -22,7 +22,7 @@ instead be performed with a GLM.}
 
 \item{skip_gee}{When TRUE doesn't try to optimize with a GEE (just uses a GLM). This should only be used internally for testing.}
 
-\item{...}{Arguments that you would pass to a regular \code{geepack::geeglm} call. Any observations with \code{NA} values in the data (response or covariates) will be dropped.}
+\item{...}{Arguments that you would pass to a regular \code{geepack::geeglm} call. Any observations with \code{NA} values in the data (response or covariates or id) will be dropped.}
 }
 \description{
 Generalized Estimating Equations under technical replication with robust and non-robust Wald and Rao (score) tests


### PR DESCRIPTION
This is related to `enviromtx` [issue 27](https://github.com/statdivlab/enviromtx/issues/27). Here, we have cases where `fit_mgx_model()` fails, and can be traced back to `robust_score_test()` and specifically the line `Umatrices[[ii]] <- Di %*% solve(Vi, matrix(Si, ncol = 1))`, with an error about `Vi` being computationally singular. We address this in this PR by adding a small ridge penalty to the `Vi` matrix to try to invert it. This penalty starts very small and increases to a moderate size, before hitting an error. The goal is for this to address most cases in which `fit_mgx_model()` is failing with this error. In the two cases that I have where this happens, the regularization procedure in this PR fixes the problem. 